### PR TITLE
feat:Make weights property optional in DeployLLMConfig OpenAPI schema

### DIFF
--- a/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployLLMConfig.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployLLMConfig.g.cs
@@ -34,8 +34,7 @@ namespace DeepInfra
         /// Model weights information
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("weights")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required global::DeepInfra.HFWeights Weights { get; set; }
+        public global::DeepInfra.HFWeights? Weights { get; set; }
 
         /// <summary>
         /// Additional properties that are not explicitly defined in the schema
@@ -65,12 +64,12 @@ namespace DeepInfra
             global::DeepInfra.DeployGPUs gpu,
             int numGpus,
             int maxBatchSize,
-            global::DeepInfra.HFWeights weights)
+            global::DeepInfra.HFWeights? weights)
         {
             this.Gpu = gpu;
             this.NumGpus = numGpus;
             this.MaxBatchSize = maxBatchSize;
-            this.Weights = weights ?? throw new global::System.ArgumentNullException(nameof(weights));
+            this.Weights = weights;
         }
 
         /// <summary>

--- a/src/libs/DeepInfra/openapi.yaml
+++ b/src/libs/DeepInfra/openapi.yaml
@@ -3767,7 +3767,6 @@ components:
         - gpu
         - num_gpus
         - max_batch_size
-        - weights
       type: object
       properties:
         gpu:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Made the "weights" field optional in the deployment configuration schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->