### PR TITLE
feat:Add "other" value to DeployGPUs enum in OpenAPI specification

### DIFF
--- a/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployGPUs.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployGPUs.g.cs
@@ -24,6 +24,10 @@ namespace DeepInfra
         /// 
         /// </summary>
         B200180GB,
+        /// <summary>
+        /// 
+        /// </summary>
+        Other,
     }
 
     /// <summary>
@@ -42,6 +46,7 @@ namespace DeepInfra
                 DeployGPUs.H10080GB => "H100-80GB",
                 DeployGPUs.H200141GB => "H200-141GB",
                 DeployGPUs.B200180GB => "B200-180GB",
+                DeployGPUs.Other => "other",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -56,6 +61,7 @@ namespace DeepInfra
                 "H100-80GB" => DeployGPUs.H10080GB,
                 "H200-141GB" => DeployGPUs.H200141GB,
                 "B200-180GB" => DeployGPUs.B200180GB,
+                "other" => DeployGPUs.Other,
                 _ => null,
             };
         }

--- a/src/libs/DeepInfra/openapi.yaml
+++ b/src/libs/DeepInfra/openapi.yaml
@@ -3916,6 +3916,7 @@ components:
         - H100-80GB
         - H200-141GB
         - B200-180GB
+        - other
       type: string
     DeployInstances:
       title: DeployInstances


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying "other" as a GPU type option when deploying, in addition to existing GPU types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->