### PR TITLE
feat:Add optional dimensions property to OpenAIEmbeddingsIn schema in OpenAPI

### DIFF
--- a/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.OpenaiEmbeddings.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.OpenaiEmbeddings.g.cs
@@ -239,6 +239,10 @@ namespace DeepInfra
         /// format used when encoding<br/>
         /// Default Value: float
         /// </param>
+        /// <param name="dimensions">
+        /// The number of dimensions in the embedding. If not provided, the model's default will be used.If provided bigger than model's default, the embedding will be padded with zeros.<br/>
+        /// Example: 1536
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<string> OpenaiEmbeddingsAsync(
@@ -248,6 +252,7 @@ namespace DeepInfra
             string? userAgent = default,
             string? xiApiKey = default,
             global::DeepInfra.OpenAIEmbeddingsInEncodingFormat? encodingFormat = default,
+            int? dimensions = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::DeepInfra.OpenAIEmbeddingsIn
@@ -255,6 +260,7 @@ namespace DeepInfra
                 Model = model,
                 Input = input,
                 EncodingFormat = encodingFormat,
+                Dimensions = dimensions,
             };
 
             return await OpenaiEmbeddingsAsync(

--- a/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.OpenaiEmbeddings.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.OpenaiEmbeddings.g.cs
@@ -38,6 +38,10 @@ namespace DeepInfra
         /// format used when encoding<br/>
         /// Default Value: float
         /// </param>
+        /// <param name="dimensions">
+        /// The number of dimensions in the embedding. If not provided, the model's default will be used.If provided bigger than model's default, the embedding will be padded with zeros.<br/>
+        /// Example: 1536
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<string> OpenaiEmbeddingsAsync(
@@ -47,6 +51,7 @@ namespace DeepInfra
             string? userAgent = default,
             string? xiApiKey = default,
             global::DeepInfra.OpenAIEmbeddingsInEncodingFormat? encodingFormat = default,
+            int? dimensions = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/DeepInfra/Generated/DeepInfra.Models.OpenAIEmbeddingsIn.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.Models.OpenAIEmbeddingsIn.g.cs
@@ -38,6 +38,14 @@ namespace DeepInfra
         public global::DeepInfra.OpenAIEmbeddingsInEncodingFormat? EncodingFormat { get; set; }
 
         /// <summary>
+        /// The number of dimensions in the embedding. If not provided, the model's default will be used.If provided bigger than model's default, the embedding will be padded with zeros.<br/>
+        /// Example: 1536
+        /// </summary>
+        /// <example>1536</example>
+        [global::System.Text.Json.Serialization.JsonPropertyName("dimensions")]
+        public int? Dimensions { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -58,17 +66,23 @@ namespace DeepInfra
         /// format used when encoding<br/>
         /// Default Value: float
         /// </param>
+        /// <param name="dimensions">
+        /// The number of dimensions in the embedding. If not provided, the model's default will be used.If provided bigger than model's default, the embedding will be padded with zeros.<br/>
+        /// Example: 1536
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public OpenAIEmbeddingsIn(
             string model,
             global::DeepInfra.AnyOf<global::System.Collections.Generic.IList<string>, string> input,
-            global::DeepInfra.OpenAIEmbeddingsInEncodingFormat? encodingFormat)
+            global::DeepInfra.OpenAIEmbeddingsInEncodingFormat? encodingFormat,
+            int? dimensions)
         {
             this.Model = model ?? throw new global::System.ArgumentNullException(nameof(model));
             this.Input = input;
             this.EncodingFormat = encodingFormat;
+            this.Dimensions = dimensions;
         }
 
         /// <summary>

--- a/src/libs/DeepInfra/openapi.yaml
+++ b/src/libs/DeepInfra/openapi.yaml
@@ -6125,6 +6125,13 @@ components:
           type: string
           description: format used when encoding
           default: float
+        dimensions:
+          title: Dimensions
+          minimum: 32.0
+          type: integer
+          description: 'The number of dimensions in the embedding. If not provided, the model''s default will be used.If provided bigger than model''s default, the embedding will be padded with zeros.'
+          nullable: true
+          example: 1536
     OpenAIImageData:
       title: OpenAIImageData
       required:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for specifying the number of dimensions in embedding vectors. If not provided, the model's default is used; if larger, embeddings are zero-padded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->