### PR TITLE
feat:Add unix_timestamp format to from in payment usage OpenAPI docs

### DIFF
--- a/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.Usage.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.Usage.g.cs
@@ -29,7 +29,7 @@ namespace DeepInfra
         /// Usage
         /// </summary>
         /// <param name="from">
-        /// start of period, YYYY.MM or current(-N) format
+        /// start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format
         /// </param>
         /// <param name="to">
         /// end of period (if missing a single month marked by from is return), same format as from

--- a/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.UsageApiToken.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.DeepInfraClient.UsageApiToken.g.cs
@@ -32,7 +32,7 @@ namespace DeepInfra
         /// </summary>
         /// <param name="apiToken"></param>
         /// <param name="from">
-        /// start of period, YYYY.MM or current(-N) format
+        /// start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format
         /// </param>
         /// <param name="to">
         /// end of period (if missing a single month marked by from is return), same format as from

--- a/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.Usage.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.Usage.g.cs
@@ -8,7 +8,7 @@ namespace DeepInfra
         /// Usage
         /// </summary>
         /// <param name="from">
-        /// start of period, YYYY.MM or current(-N) format
+        /// start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format
         /// </param>
         /// <param name="to">
         /// end of period (if missing a single month marked by from is return), same format as from

--- a/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.UsageApiToken.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.IDeepInfraClient.UsageApiToken.g.cs
@@ -9,7 +9,7 @@ namespace DeepInfra
         /// </summary>
         /// <param name="apiToken"></param>
         /// <param name="from">
-        /// start of period, YYYY.MM or current(-N) format
+        /// start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format
         /// </param>
         /// <param name="to">
         /// end of period (if missing a single month marked by from is return), same format as from

--- a/src/libs/DeepInfra/openapi.yaml
+++ b/src/libs/DeepInfra/openapi.yaml
@@ -3559,12 +3559,12 @@ paths:
       parameters:
         - name: from
           in: query
-          description: 'start of period, YYYY.MM or current(-N) format'
+          description: 'start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format'
           required: true
           schema:
             title: From
             type: string
-            description: 'start of period, YYYY.MM or current(-N) format'
+            description: 'start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format'
         - name: to
           in: query
           description: 'end of period (if missing a single month marked by from is return), same format as from'
@@ -3645,12 +3645,12 @@ paths:
             type: string
         - name: from
           in: query
-          description: 'start of period, YYYY.MM or current(-N) format'
+          description: 'start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format'
           required: true
           schema:
             title: From
             type: string
-            description: 'start of period, YYYY.MM or current(-N) format'
+            description: 'start of period in YYYY.MM, current(-N), unix_timestamp (in seconds, UTC) format'
         - name: to
           in: query
           description: 'end of period (if missing a single month marked by from is return), same format as from'


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated API documentation to clarify accepted formats for the "from" query parameter on payment usage endpoints.
  - The parameter now explicitly documents support for YYYY.MM, current(-N), and Unix timestamp (seconds, UTC).
  - Applied to both payment usage endpoints to ensure consistency and reduce ambiguity for integrators.
  - No changes to parameter requirements, types, or responses; this is a clarification to improve understanding and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->