### PR TITLE
feat:Add L4-24GB and L40S-48GB to DeployGPUs enum in DeepInfra OpenAPI

### DIFF
--- a/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployGPUs.g.cs
+++ b/src/libs/DeepInfra/Generated/DeepInfra.Models.DeployGPUs.g.cs
@@ -11,6 +11,14 @@ namespace DeepInfra
         /// <summary>
         /// 
         /// </summary>
+        L424GB,
+        /// <summary>
+        /// 
+        /// </summary>
+        L40S48GB,
+        /// <summary>
+        /// 
+        /// </summary>
         A10080GB,
         /// <summary>
         /// 
@@ -42,6 +50,8 @@ namespace DeepInfra
         {
             return value switch
             {
+                DeployGPUs.L424GB => "L4-24GB",
+                DeployGPUs.L40S48GB => "L40S-48GB",
                 DeployGPUs.A10080GB => "A100-80GB",
                 DeployGPUs.H10080GB => "H100-80GB",
                 DeployGPUs.H200141GB => "H200-141GB",
@@ -57,6 +67,8 @@ namespace DeepInfra
         {
             return value switch
             {
+                "L4-24GB" => DeployGPUs.L424GB,
+                "L40S-48GB" => DeployGPUs.L40S48GB,
                 "A100-80GB" => DeployGPUs.A10080GB,
                 "H100-80GB" => DeployGPUs.H10080GB,
                 "H200-141GB" => DeployGPUs.H200141GB,

--- a/src/libs/DeepInfra/openapi.yaml
+++ b/src/libs/DeepInfra/openapi.yaml
@@ -5505,6 +5505,8 @@ components:
     DeployGPUs:
       title: DeployGPUs
       enum:
+        - L4-24GB
+        - L40S-48GB
         - A100-80GB
         - H100-80GB
         - H200-141GB


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new GPU options: NVIDIA L4 (24 GB) and L40S (48 GB) for deployments.
  * These GPUs are now selectable wherever deployment hardware is configured, including API-driven workflows and any UI dropdowns tied to the spec.
  * Expands deployment flexibility and performance choices without impacting existing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->